### PR TITLE
Fixed toot/otto gametype bug

### DIFF
--- a/client/controllers/connect4.rb
+++ b/client/controllers/connect4.rb
@@ -93,9 +93,9 @@ class Connect4
       @config.alg = :AlphaBetaPruning
       configure_bot
     when MenuClickEvent::PVP
-      @config.players[1] = PlayerFactory::player(@game_type, PlayerFactory::PLAYER_2, 'p2')
+      @config.players[1] = PlayerFactory::player2(@game_type, 'p2')
     when MenuClickEvent::CONNECT4
-      @game_type = Connect4GameType.instance
+      @config.game_type = @game_type = Connect4GameType.instance
       @config.players[0].counters = @game_type.p1_counters
       if @config.players[1].instance_of? ComputerPlayer
         configure_bot
@@ -103,7 +103,7 @@ class Connect4
         @config.players[1].counters = @game_type.p2_counters
       end
     when MenuClickEvent::TOOT_OTTO
-      @game_type = TootOttoGameType.instance
+      @config.game_type = @game_type = TootOttoGameType.instance
       @config.players[0].counters = @game_type.p1_counters
       if @config.players[1].instance_of? ComputerPlayer
         configure_bot

--- a/client/resources/ui/offline_game_menu_window.ui
+++ b/client/resources/ui/offline_game_menu_window.ui
@@ -34,7 +34,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkRadioButton" id="connect4_btn">
+      <object class="GtkRadioButton" id="connect4_radio_btn">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
@@ -68,13 +68,13 @@
       </packing>
     </child>
     <child>
-      <object class="GtkRadioButton" id="toot_otto_btn">
+      <object class="GtkRadioButton" id="toot_otto_radio_btn">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">False</property>
         <property name="xalign">0.5</property>
         <property name="draw_indicator">False</property>
-        <property name="group">connect4_btn</property>
+        <property name="group">connect4_radio_btn</property>
         <child>
           <object class="GtkHBox" id="toot_otto_btn_widget">
             <property name="visible">True</property>

--- a/client/views/windows/offline_game_menu_window.rb
+++ b/client/views/windows/offline_game_menu_window.rb
@@ -16,9 +16,9 @@ module C4
       def init
         set_template(:resource => "/com/rubynetix/connect4/ui/offline_game_menu_window.ui")
 
-        bind_template_child("connect4_btn")
+        bind_template_child("connect4_radio_btn")
         bind_template_child("connect4_btn_widget")
-        bind_template_child("toot_otto_btn")
+        bind_template_child("toot_otto_radio_btn")
         bind_template_child("toot_otto_btn_widget")
         bind_template_child("pvp_btn")
         bind_template_child("pvc_btn")
@@ -42,9 +42,9 @@ module C4
 
     def init_menu
       # Menu options
-      @menu_c4 = connect4_btn
+      @menu_c4 = connect4_radio_btn
       @menu_c4.mode = false
-      @menu_to = toot_otto_btn
+      @menu_to = toot_otto_radio_btn
       @menu_to.mode = false
       @menu_pvp = pvp_btn
       @menu_pvp.mode = false
@@ -66,12 +66,20 @@ module C4
 
       # Event signals
       @menu_start.signal_connect("clicked") {notify_all(MenuClickEvent.new(MenuClickEvent::START))}
-      @menu_c4.signal_connect("clicked") {notify_all(MenuClickEvent.new(MenuClickEvent::CONNECT4))}
-      @menu_to.signal_connect("clicked") {notify_all(MenuClickEvent.new(MenuClickEvent::TOOT_OTTO))}
+      @menu_c4.signal_connect("clicked") {handle_radio_click}
+      @menu_to.signal_connect("clicked") {handle_radio_click}
       @menu_pvp.signal_connect("clicked") {notify_all(MenuClickEvent.new(MenuClickEvent::PVP))}
       @menu_pvc.signal_connect("clicked") {notify_all(MenuClickEvent.new(MenuClickEvent::PVC_EASY))}
       @menu_pvc_hard.signal_connect("clicked") {notify_all(MenuClickEvent.new(MenuClickEvent::PVC_HARD))}
       @back_btn.signal_connect('clicked') {notify_all(WindowChangeEvent.new(MainMenuWindow.class_variable_get(:@@wid)))}
+    end
+
+    def handle_radio_click
+      if @menu_c4.active?
+        notify_all(MenuClickEvent.new(MenuClickEvent::CONNECT4))
+      elsif @menu_to.active?
+        notify_all(MenuClickEvent.new(MenuClickEvent::TOOT_OTTO))
+      end
     end
 
     def load_image(path)


### PR DESCRIPTION
Toot/otto gameboard was the incorrect size in offline mode due to a bug with signals being sent from the same radio button group.